### PR TITLE
FIX : No element displayed in the order box

### DIFF
--- a/htdocs/core/boxes/box_commandes.php
+++ b/htdocs/core/boxes/box_commandes.php
@@ -121,7 +121,7 @@ class box_commandes extends ModeleBoxes
 			$result = $this->db->query($sql);
 			if ($result) {
 				$num = $this->db->num_rows($result);
-				$num=0;
+				
 				$line = 0;
 
 				while ($line < $num) {


### PR DESCRIPTION
# FIX : No element displayed in order box
Removing the attribution to 0 for $num which caused to never display any order

